### PR TITLE
Monitoring refactor

### DIFF
--- a/infra/broker.tf
+++ b/infra/broker.tf
@@ -25,14 +25,14 @@ resource "azurerm_servicebus_namespace" "amb_svcbus_ns" {
 }
 
 resource "azurerm_servicebus_queue" "amb_queue" {
-  for_each              = local.queues
+  for_each              = local.queues.names
   name                  = each.key
   namespace_id          = azurerm_servicebus_namespace.amb_svcbus_ns.id
   max_size_in_megabytes = 1024
 }
 
 resource "azurerm_servicebus_topic" "amb_topic" {
-  for_each     = local.topics
+  for_each     = local.topics.names
   name         = each.key
   namespace_id = azurerm_servicebus_namespace.amb_svcbus_ns.id
 }

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,13 +1,21 @@
 locals {
   topics = {
-    "customer-created" = ""
-    "customer-updated" = ""
-    "region-added"     = ""
+    "threshold" = 10000
+    "severity"  = 1
+    "names" = {
+      "customer-created" = ""
+      "customer-updated" = ""
+      "region-added"     = ""
+    }
   }
   queues = {
-    "activate-customer"   = ""
-    "deactivate-customer" = ""
-    "email-customer"      = ""
+    "threshold" = 50
+    "severity"  = 2
+    "names" = {
+      "activate-customer"   = ""
+      "deactivate-customer" = ""
+      "email-customer"      = ""
+    }
   }
   functions = {
     "amb-send-email"              = ""

--- a/infra/monitor.tf
+++ b/infra/monitor.tf
@@ -18,30 +18,15 @@ resource "azurerm_monitor_action_group" "amb_monitor_group_main" {
   }
 }
 
-
-# Dynamic criteria not supported for metric type
-# Static criteria used, may require adjustments over time
-resource "azurerm_monitor_metric_alert" "amb_alert_queue_topic_volume_irregular" {
-  name                = "amb-alert-queue-topic-volume-irregular-${var.env_name}"
+module "service_bus_alerts" {
+  for_each            = merge({ topics = local.topics }, { queues = local.queues })
+  source              = "../modules/servicebusalert"
+  env_name            = var.env_name
   resource_group_name = azurerm_resource_group.amb_monitor_rg.name
-  scopes              = [azurerm_servicebus_namespace.amb_svcbus_ns.id]
-  description         = "Monitors if queue or topic volumes becomes overloaded which may indicate issues with processing"
-
-  criteria {
-    metric_namespace = "microsoft.servicebus/namespaces"
-    metric_name      = "ActiveMessages"
-    aggregation      = "Average"
-    operator         = "GreaterThan"
-    threshold        = 100
-
-    dimension {
-      name     = "EntityName"
-      operator = "Include"
-      values   = keys(merge(local.queues, local.topics))
-    }
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.amb_monitor_group_main.id
-  }
+  scope               = azurerm_servicebus_namespace.amb_svcbus_ns.id
+  dimension_values    = keys(each.value.names)
+  action_group_id     = azurerm_monitor_action_group.amb_monitor_group_main.id
+  threshold           = each.value.threshold
+  type                = each.key
+  severity            = each.value.severity
 }

--- a/infra/monitor.tf
+++ b/infra/monitor.tf
@@ -18,29 +18,30 @@ resource "azurerm_monitor_action_group" "amb_monitor_group_main" {
   }
 }
 
-# Commented out due to bug/limitation in building monitor
-# https://github.com/hashicorp/terraform-provider-azurerm/issues/20944
-# resource "azurerm_monitor_metric_alert" "amb_alert_queue_topic_volume_irregular" {
-#   name                = "amb-alert-queue-topic-volume-irregular-${var.env_name}"
-#   resource_group_name = azurerm_resource_group.amb_monitor_rg.name
-#   scopes              = [azurerm_servicebus_namespace.amb_svcbus_ns.id]
-#   description         = "Monitors if queue or topic volumes become irregular"
 
-#   dynamic_criteria {
-#     metric_namespace  = "microsoft.servicebus/namespaces"
-#     metric_name       = "ActiveMessages"
-#     aggregation       = "Average"
-#     operator          = "GreaterOrLessThan"
-#     alert_sensitivity = "High"
+# Dynamic criteria not supported for metric type
+# Static criteria used, may require adjustments over time
+resource "azurerm_monitor_metric_alert" "amb_alert_queue_topic_volume_irregular" {
+  name                = "amb-alert-queue-topic-volume-irregular-${var.env_name}"
+  resource_group_name = azurerm_resource_group.amb_monitor_rg.name
+  scopes              = [azurerm_servicebus_namespace.amb_svcbus_ns.id]
+  description         = "Monitors if queue or topic volumes becomes overloaded which may indicate issues with processing"
 
-#     dimension {
-#       name     = "EntityName"
-#       operator = "Include"
-#       values   = ["*"]
-#     }
-#   }
+  criteria {
+    metric_namespace = "microsoft.servicebus/namespaces"
+    metric_name      = "ActiveMessages"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 100
 
-#   action {
-#     action_group_id = azurerm_monitor_action_group.amb_monitor_group_main.id
-#   }
-# }
+    dimension {
+      name     = "EntityName"
+      operator = "Include"
+      values   = keys(merge(local.queues, local.topics))
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.amb_monitor_group_main.id
+  }
+}

--- a/modules/servicebusalert/resources.tf
+++ b/modules/servicebusalert/resources.tf
@@ -1,0 +1,25 @@
+resource "azurerm_monitor_metric_alert" "amb_alert_queue_topic_volume_irregular" {
+  name                = "amb-alert-${var.type}-volume-irregular-${var.env_name}"
+  resource_group_name = var.resource_group_name
+  scopes              = [var.scope]
+  severity            = var.severity
+  description         = "Monitors if queue or topic volumes becomes overloaded which may indicate issues with processing"
+
+  criteria {
+    metric_namespace = "microsoft.servicebus/namespaces"
+    metric_name      = "ActiveMessages"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.threshold
+
+    dimension {
+      name     = "EntityName"
+      operator = "Include"
+      values   = var.dimension_values
+    }
+  }
+
+  action {
+    action_group_id = var.action_group_id
+  }
+}

--- a/modules/servicebusalert/variables.tf
+++ b/modules/servicebusalert/variables.tf
@@ -1,0 +1,41 @@
+variable "env_name" {
+  description = "Working environment"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Monitoring resource group"
+  type        = string
+}
+
+variable "scope" {
+  description = "ID of service bus namespace"
+  type        = string
+}
+
+variable "threshold" {
+  description = "Number of messages on queues/topics before alarm trips"
+  type        = number
+  default     = 100
+}
+
+variable "dimension_values" {
+  description = "List of queues/topics to be monitored"
+  type        = list(any)
+}
+
+variable "action_group_id" {
+  description = "Monitoring action group"
+  type        = string
+}
+
+variable "type" {
+  description = "Alert type"
+  type        = string
+}
+
+variable "severity" {
+  description = "Alert severity level"
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
Summary: Monitoring was refactored to utilize the newly built module

-----

**Module**

- Built to enable dynamic development of monitoring associated with service bus queues and topics

**Monitoring**

- Removed dynamic criteria as it was [determined to be unsupported ](https://github.com/hashicorp/terraform-provider-azurerm/issues/20944)
- Added manual criteria
- Leveraged module and for_each loop with updated locals.tf values to enable granularity in monitoring settings